### PR TITLE
Diverse Gutenberg blocks + extra opties voor pagina's, berichten en speelset-taxonomie

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,13 +1,21 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <PHPCodeStyleSettings>
+      <option name="ALIGN_KEY_VALUE_PAIRS" value="true" />
+      <option name="ALIGN_ASSIGNMENTS" value="true" />
       <option name="COMMA_AFTER_LAST_ARRAY_ELEMENT" value="true" />
       <option name="PHPDOC_BLANK_LINE_BEFORE_TAGS" value="true" />
       <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
       <option name="PHPDOC_WRAP_LONG_LINES" value="true" />
       <option name="UPPER_CASE_BOOLEAN_CONST" value="true" />
       <option name="UPPER_CASE_NULL_CONST" value="true" />
+      <option name="VARIABLE_NAMING_STYLE" value="SNAKE_CASE" />
+      <option name="BLANK_LINES_BEFORE_RETURN_STATEMENT" value="1" />
+      <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
+      <option name="SPACES_AROUND_VAR_WITHIN_BRACKETS" value="true" />
       <option name="BLANK_LINES_AROUND_CONSTANTS" value="1" />
+      <option name="SPACE_BEFORE_UNARY_NOT" value="true" />
+      <option name="SPACE_AFTER_UNARY_NOT" value="true" />
       <option name="FORCE_SHORT_DECLARATION_ARRAY_STYLE" value="true" />
       <option name="PHPDOC_USE_FQCN" value="true" />
     </PHPCodeStyleSettings>
@@ -30,14 +38,33 @@
       <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
       <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
       <option name="BLANK_LINES_AFTER_PACKAGE" value="1" />
-      <option name="BLANK_LINES_AROUND_FIELD" value="1" />
       <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
       <option name="CLASS_BRACE_STYLE" value="1" />
       <option name="METHOD_BRACE_STYLE" value="1" />
-      <option name="ELSE_ON_NEW_LINE" value="true" />
+      <option name="SPECIAL_ELSE_IF_TREATMENT" value="true" />
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="SPACE_AROUND_UNARY_OPERATOR" value="true" />
+      <option name="SPACE_WITHIN_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
       <option name="SPACE_AFTER_TYPE_CAST" value="true" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
       <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="PARENTHESES_EXPRESSION_LPAREN_WRAP" value="true" />
+      <option name="PARENTHESES_EXPRESSION_RPAREN_WRAP" value="true" />
       <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="FOR_STATEMENT_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_RPAREN_ON_NEXT_LINE" value="true" />
       <option name="ARRAY_INITIALIZER_WRAP" value="5" />
       <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
       <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
@@ -46,9 +73,8 @@
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
       <indentOptions>
-        <option name="INDENT_SIZE" value="2" />
-        <option name="CONTINUATION_INDENT_SIZE" value="2" />
-        <option name="TAB_SIZE" value="2" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+        <option name="SMART_TABS" value="true" />
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="Twig">

--- a/acf-json/group_5c8f9ba967736.json
+++ b/acf-json/group_5c8f9ba967736.json
@@ -32,7 +32,7 @@
             "name": "content_block_title",
             "type": "text",
             "instructions": "",
-            "required": 1,
+            "required": 0,
             "conditional_logic": [
                 [
                     {
@@ -104,8 +104,7 @@
             "choices": {
                 "posts": "Losse items, zoals pagina's, berichten, tips",
                 "taxonomie_speelset: Speelsets": "taxonomie_speelset: Speelsets",
-                "taxonomie_tipgevers: Tipgevers": "taxonomie_tipgevers: Tipgevers",
-                "taxonomie_asdf: xxx": "taxonomie_asdf: xxx"
+                "taxonomie_tipgevers: Tipgevers": "taxonomie_tipgevers: Tipgevers"
             },
             "allow_null": 0,
             "other_choice": 0,
@@ -233,6 +232,13 @@
                 "operator": "==",
                 "value": "page"
             }
+        ],
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/gc-related"
+            }
         ]
     ],
     "menu_order": 0,
@@ -243,5 +249,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1594063698
+    "modified": 1594117955
 }

--- a/acf-json/group_5c8f9ba967736.json
+++ b/acf-json/group_5c8f9ba967736.json
@@ -1,6 +1,6 @@
 {
     "key": "group_5c8f9ba967736",
-    "title": "Gerelateerde content",
+    "title": "GC - gerelateerde content",
     "fields": [
         {
             "key": "field_5c8fe203a8435",
@@ -153,8 +153,8 @@
             "elements": [
                 "featured_image"
             ],
-            "min": "",
-            "max": "",
+            "min": 1,
+            "max": 3,
             "return_format": "object"
         },
         {
@@ -189,7 +189,7 @@
         },
         {
             "key": "field_5f033df83c8e7",
-            "label": "Gerelateerde taxonomie: speelsets",
+            "label": "Speelsets",
             "name": "content_block_taxonomy_speelsets",
             "type": "taxonomy",
             "instructions": "",
@@ -249,5 +249,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1594117955
+    "modified": 1594214358
 }

--- a/acf-json/group_5c8f9ba967736.json
+++ b/acf-json/group_5c8f9ba967736.json
@@ -1,0 +1,247 @@
+{
+    "key": "group_5c8f9ba967736",
+    "title": "Gerelateerde content",
+    "fields": [
+        {
+            "key": "field_5c8fe203a8435",
+            "label": "Gerelateerde content toevoegen?",
+            "name": "gerelateerde_content_toevoegen",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "ja": "Ja",
+                "nee": "Nee"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "nee",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_5c8fd404bd765",
+            "label": "Title",
+            "name": "content_block_title",
+            "type": "text",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5c8fe203a8435",
+                        "operator": "==",
+                        "value": "ja"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5f03390be2d81",
+            "label": "description",
+            "name": "content_block_description",
+            "type": "textarea",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5c8fe203a8435",
+                        "operator": "==",
+                        "value": "ja"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "maxlength": "",
+            "rows": "",
+            "new_lines": ""
+        },
+        {
+            "key": "field_5f033a4dfaec8",
+            "label": "Wat wil je tonen?",
+            "name": "content_block_types",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5c8fe203a8435",
+                        "operator": "==",
+                        "value": "ja"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "posts": "Losse items, zoals pagina's, berichten, tips",
+                "taxonomie_speelset: Speelsets": "taxonomie_speelset: Speelsets",
+                "taxonomie_tipgevers: Tipgevers": "taxonomie_tipgevers: Tipgevers",
+                "taxonomie_asdf: xxx": "taxonomie_asdf: xxx"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "posts",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_5c8fd42e15a23",
+            "label": "Gerelateerde items",
+            "name": "content_block_items",
+            "type": "relationship",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5c8fe203a8435",
+                        "operator": "==",
+                        "value": "ja"
+                    },
+                    {
+                        "field": "field_5f033a4dfaec8",
+                        "operator": "==",
+                        "value": "posts"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "post",
+                "page",
+                "tips"
+            ],
+            "taxonomy": "",
+            "filters": [
+                "search",
+                "post_type",
+                "taxonomy"
+            ],
+            "elements": [
+                "featured_image"
+            ],
+            "min": "",
+            "max": "",
+            "return_format": "object"
+        },
+        {
+            "key": "field_5f033a2f8c7f0",
+            "label": "Tipgevers",
+            "name": "content_block_taxonomy_tipgever",
+            "type": "taxonomy",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f033a4dfaec8",
+                        "operator": "==",
+                        "value": "taxonomie_tipgevers"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "tipgever",
+            "field_type": "multi_select",
+            "allow_null": 0,
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "multiple": 0
+        },
+        {
+            "key": "field_5f033df83c8e7",
+            "label": "Gerelateerde taxonomie: speelsets",
+            "name": "content_block_taxonomy_speelsets",
+            "type": "taxonomy",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f033a4dfaec8",
+                        "operator": "==",
+                        "value": "taxonomie_speelset"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "tipgever",
+            "field_type": "multi_select",
+            "allow_null": 1,
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "multiple": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "page"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1594063698
+}

--- a/acf-json/group_5c8f9ba967736.json
+++ b/acf-json/group_5c8f9ba967736.json
@@ -142,7 +142,8 @@
             "post_type": [
                 "post",
                 "page",
-                "tips"
+                "tips",
+                "event"
             ],
             "taxonomy": "",
             "filters": [
@@ -239,6 +240,27 @@
                 "operator": "==",
                 "value": "acf\/gc-related"
             }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "event"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "location"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "event-recurring"
+            }
         ]
     ],
     "menu_order": 0,
@@ -249,5 +271,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1594214358
+    "modified": 1594215180
 }

--- a/acf-json/group_5c8f9ba967736.json
+++ b/acf-json/group_5c8f9ba967736.json
@@ -28,10 +28,10 @@
         },
         {
             "key": "field_5c8fd404bd765",
-            "label": "Title",
+            "label": "Titel",
             "name": "content_block_title",
             "type": "text",
-            "instructions": "",
+            "instructions": "(niet verplicht)",
             "required": 0,
             "conditional_logic": [
                 [
@@ -58,7 +58,7 @@
             "label": "description",
             "name": "content_block_description",
             "type": "textarea",
-            "instructions": "",
+            "instructions": "(niet verplicht)",
             "required": 0,
             "conditional_logic": [
                 [
@@ -86,7 +86,7 @@
             "name": "content_block_types",
             "type": "radio",
             "instructions": "",
-            "required": 0,
+            "required": 1,
             "conditional_logic": [
                 [
                     {
@@ -103,8 +103,8 @@
             },
             "choices": {
                 "posts": "Losse items, zoals pagina's, berichten, tips",
-                "taxonomie_speelset: Speelsets": "taxonomie_speelset: Speelsets",
-                "taxonomie_tipgevers: Tipgevers": "taxonomie_tipgevers: Tipgevers"
+                "taxonomie_speelset": "Speelsets",
+                "taxonomie_tipgevers": "Tipgevers"
             },
             "allow_null": 0,
             "other_choice": 0,
@@ -118,7 +118,7 @@
             "label": "Gerelateerde items",
             "name": "content_block_items",
             "type": "relationship",
-            "instructions": "",
+            "instructions": "Kies uit events, berichten, pagina's en tips. Minimaal 1, maximaal 3.",
             "required": 0,
             "conditional_logic": [
                 [
@@ -159,6 +159,36 @@
             "return_format": "object"
         },
         {
+            "key": "field_5f033df83c8e7",
+            "label": "Speelsets",
+            "name": "content_block_taxonomy_speelsets",
+            "type": "taxonomy",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f033a4dfaec8",
+                        "operator": "==",
+                        "value": "taxonomie_speelset"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "speelset",
+            "field_type": "checkbox",
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "object",
+            "multiple": 0,
+            "allow_null": 0
+        },
+        {
             "key": "field_5f033a2f8c7f0",
             "label": "Tipgevers",
             "name": "content_block_taxonomy_tipgever",
@@ -189,34 +219,28 @@
             "multiple": 0
         },
         {
-            "key": "field_5f033df83c8e7",
-            "label": "Speelsets",
-            "name": "content_block_taxonomy_speelsets",
-            "type": "taxonomy",
+            "key": "field_5f05d0290d8a8",
+            "label": "Achtergrond",
+            "name": "content_block_modifier",
+            "type": "radio",
             "instructions": "",
-            "required": 0,
-            "conditional_logic": [
-                [
-                    {
-                        "field": "field_5f033a4dfaec8",
-                        "operator": "==",
-                        "value": "taxonomie_speelset"
-                    }
-                ]
-            ],
+            "required": 1,
+            "conditional_logic": 0,
             "wrapper": {
                 "width": "",
                 "class": "",
                 "id": ""
             },
-            "taxonomy": "tipgever",
-            "field_type": "multi_select",
-            "allow_null": 1,
-            "add_term": 0,
-            "save_terms": 0,
-            "load_terms": 0,
-            "return_format": "id",
-            "multiple": 0
+            "choices": {
+                "none": "Toon geen achtergrond",
+                "bg-option": "Toon achtergrond"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "none",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
         }
     ],
     "location": [
@@ -271,5 +295,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1594215180
+    "modified": 1594217055
 }

--- a/acf-json/group_5efa247d90410.json
+++ b/acf-json/group_5efa247d90410.json
@@ -1,6 +1,6 @@
 {
     "key": "group_5efa247d90410",
-    "title": "Downloads",
+    "title": "GC - Lijst met downloads",
     "fields": [
         {
             "key": "field_5efa247da4f57",
@@ -315,5 +315,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1593465812
+    "modified": 1594215891
 }

--- a/acf-json/group_5efa86188abea.json
+++ b/acf-json/group_5efa86188abea.json
@@ -1,0 +1,50 @@
+{
+    "key": "group_5efa86188abea",
+    "title": "Inleiding voor landingspagina",
+    "fields": [
+        {
+            "key": "field_5efa86304a7fa",
+            "label": "Inleiding",
+            "name": "post_inleiding",
+            "type": "wysiwyg",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "tabs": "all",
+            "toolbar": "basic",
+            "media_upload": 0,
+            "delay": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "template-landingspagina.php"
+            }
+        ],
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "template-alle-tips.php"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "acf_after_title",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1594214328
+}

--- a/acf-json/group_5f03007497d84.json
+++ b/acf-json/group_5f03007497d84.json
@@ -1,0 +1,65 @@
+{
+    "key": "group_5f03007497d84",
+    "title": "GC Gutenberg Call To Action",
+    "fields": [
+        {
+            "key": "field_5f0300868b575",
+            "label": "Link en linktekst",
+            "name": "gc_gb_ctalink",
+            "type": "link",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array"
+        },
+        {
+            "key": "field_5f030affefe22",
+            "label": "Classes",
+            "name": "gc_gb_ctaclasses",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "btn--primary": "Primary",
+                "btn--secondary": "Secundary",
+                "btn--download": "Download"
+            },
+            "default_value": "btn--primary",
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 0,
+            "return_format": "value",
+            "ajax": 0,
+            "placeholder": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/gc-ctalink"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1594034567
+}

--- a/acf-json/group_5f04449c8cf5f.json
+++ b/acf-json/group_5f04449c8cf5f.json
@@ -1,0 +1,139 @@
+{
+    "key": "group_5f04449c8cf5f",
+    "title": "GC Text + image",
+    "fields": [
+        {
+            "key": "field_5f044501a876a",
+            "label": "Afbeelding",
+            "name": "gc_gt_textimage_image",
+            "type": "image",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "id",
+            "preview_size": "medium",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": ""
+        },
+        {
+            "key": "field_5f0444b10a7e4",
+            "label": "Tekst",
+            "name": "gc_gt_textimage_text",
+            "type": "wysiwyg",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "tabs": "all",
+            "toolbar": "basic",
+            "media_upload": 0,
+            "delay": 0
+        },
+        {
+            "key": "field_5f0445143c0f6",
+            "label": "Uitlijning",
+            "name": "gc_gt_textimage_alignment",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "align--left": "Plaatje links",
+                "align--right": "Plaatje rechts"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "align--left",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_5f0445ab18a38",
+            "label": "Breedte",
+            "name": "gc_gt_textimage_width",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "none": "Normale breedte",
+                "section--fullwidth": "Extra breed"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "none",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_5f0445f1c0fa6",
+            "label": "Achtergrondkleur",
+            "name": "gc_gt_textimage_background",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "none": "Geen achtergrondkleur",
+                "bg-color--light": "Lichte achtergrondkleur"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "none",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/gc-textimage"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1594116305
+}

--- a/acf-json/group_5f05d39c95c29.json
+++ b/acf-json/group_5f05d39c95c29.json
@@ -1,0 +1,48 @@
+{
+    "key": "group_5f05d39c95c29",
+    "title": "Speelset: Uitgelichte afbeelding",
+    "fields": [
+        {
+            "key": "field_5f05d3affc0d3",
+            "label": "Uitgelichte afbeelding",
+            "name": "speelset_uitgelichte_afbeelding",
+            "type": "image",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array",
+            "preview_size": "medium",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "taxonomy",
+                "operator": "==",
+                "value": "speelset"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1594218282
+}

--- a/acf-json/group_5f05dcb0f25a4.json
+++ b/acf-json/group_5f05dcb0f25a4.json
@@ -1,0 +1,214 @@
+{
+    "key": "group_5f05dcb0f25a4",
+    "title": "GC - Lijst met links",
+    "fields": [
+        {
+            "key": "field_5f05dcb118d13",
+            "label": "Links tonen?",
+            "name": "links_tonen",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "nee": "Nee",
+                "ja": "Ja"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "nee",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_5f05dcb118d8b",
+            "label": "Titel",
+            "name": "links_title",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f05dcb118d13",
+                        "operator": "==",
+                        "value": "ja"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "Links",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5f05dcb118e3a",
+            "label": "Inleiding",
+            "name": "links_description",
+            "type": "textarea",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f05dcb118d13",
+                        "operator": "==",
+                        "value": "ja"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "maxlength": "",
+            "rows": "",
+            "new_lines": "wpautop"
+        },
+        {
+            "key": "field_5f05dcb118eda",
+            "label": "Links",
+            "name": "links_items",
+            "type": "repeater",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f05dcb118d13",
+                        "operator": "==",
+                        "value": "ja"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "collapsed": "field_5efa2fd60e7c1",
+            "min": 1,
+            "max": 0,
+            "layout": "block",
+            "button_label": "",
+            "sub_fields": [
+                {
+                    "key": "field_5f05dcb13c489",
+                    "label": "Titel",
+                    "name": "link_item_title",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 1,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5f05dcb13c538",
+                    "label": "Korte beschrijving",
+                    "name": "link_item_description",
+                    "type": "textarea",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "maxlength": "",
+                    "rows": "",
+                    "new_lines": ""
+                },
+                {
+                    "key": "field_5f05dcb13d370",
+                    "label": "URL",
+                    "name": "link_item_url",
+                    "type": "url",
+                    "instructions": "Volledige URL, beginnend met https:\/\/ of http:\/\/",
+                    "required": 1,
+                    "conditional_logic": [
+                        [
+                            {
+                                "field": "field_5f05dcb118d13",
+                                "operator": "==",
+                                "value": "ja"
+                            }
+                        ]
+                    ],
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": ""
+                }
+            ]
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "page"
+            }
+        ],
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/gc-links"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "event"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1594220928
+}

--- a/functions.php
+++ b/functions.php
@@ -55,6 +55,7 @@ require_once( get_template_directory() . '/gutenberg-blocks/download-block.php' 
 require_once( get_template_directory() . '/gutenberg-blocks/cta-block.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/related-block.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/textimage-block.php' );
+require_once( get_template_directory() . '/gutenberg-blocks/links-block.php' );
 
 /**
  * Load other dependencies such as VAR DUMPER :D

--- a/functions.php
+++ b/functions.php
@@ -52,7 +52,7 @@ require_once( get_template_directory() . '/widgets/widget-over-ons.php' );
 // add the gutenberg blocks
 require_once( get_template_directory() . '/gutenberg-blocks/gutenberg-settings.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/download-block.php' );
-
+require_once( get_template_directory() . '/gutenberg-blocks/cta-block.php' );
 
 /**
  * Load other dependencies such as VAR DUMPER :D

--- a/functions.php
+++ b/functions.php
@@ -54,6 +54,7 @@ require_once( get_template_directory() . '/gutenberg-blocks/gutenberg-settings.p
 require_once( get_template_directory() . '/gutenberg-blocks/download-block.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/cta-block.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/related-block.php' );
+require_once( get_template_directory() . '/gutenberg-blocks/textimage-block.php' );
 
 /**
  * Load other dependencies such as VAR DUMPER :D

--- a/functions.php
+++ b/functions.php
@@ -53,6 +53,7 @@ require_once( get_template_directory() . '/widgets/widget-over-ons.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/gutenberg-settings.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/download-block.php' );
 require_once( get_template_directory() . '/gutenberg-blocks/cta-block.php' );
+require_once( get_template_directory() . '/gutenberg-blocks/related-block.php' );
 
 /**
  * Load other dependencies such as VAR DUMPER :D

--- a/functions.php
+++ b/functions.php
@@ -664,3 +664,40 @@ function gc_wbvb_get_human_filesize( $bytes, $decimals = 2 ) {
 }
 
 //========================================================================================================
+
+function get_themakleuren() {
+
+	$themakleuren = [];
+
+	// alle tipthema's langs om de kleuren op te halen
+	$args  = [
+		'taxonomy'   => GC_TIPTHEMA,
+		'hide_empty' => TRUE,
+		'orderby'    => 'name',
+		'order'      => 'ASC',
+	];
+	$terms = get_terms( $args );
+
+	if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+		$count = count( $terms );
+
+		foreach ( $terms as $term ) {
+
+			$themakleur = get_field( 'kleur_en_icoon_tipthema', GC_TIPTHEMA . '_' . $term->term_id );
+
+			if ( $themakleur ) {
+
+				$themakleuren[ $term->term_id ] = $themakleur;
+
+			} else {
+				// kleur ontbreekt
+			}
+		}
+	}
+
+	return $themakleuren;
+
+}
+
+//========================================================================================================
+

--- a/gutenberg-blocks/cta-block.php
+++ b/gutenberg-blocks/cta-block.php
@@ -2,6 +2,9 @@
 
 add_action( 'acf/init', 'gb_add_calltoaction_block' );
 
+/*
+ * Initialize the Call To Action block
+ */
 function gb_add_calltoaction_block() {
 
 	// Check function exists.
@@ -20,7 +23,9 @@ function gb_add_calltoaction_block() {
 	}
 }
 
-
+/*
+ * Render the CTA block
+ */
 function gb_render_calltoaction_block( $block, $content = '', $is_preview = FALSE ) {
 
 	$context = Timber::context();
@@ -41,28 +46,27 @@ function gb_render_calltoaction_block( $block, $content = '', $is_preview = FALS
 }
 
 /*
- * returns an array for the downloads section
+ * Collect the fields and return them
  */
 function cta_block_get_data() {
 
 	global $post;
 
 	$return           = [];
+	$cssclasses       = 'btn--primary';
 	$link             = get_field( 'gc_gb_ctalink' );
 	$gc_gb_ctaclasses = get_field( 'gc_gb_ctaclasses' );
 
-	$classsess = 'btn btn--primary';
-
 	if ( $gc_gb_ctaclasses ) {
-		$classsess = $gc_gb_ctaclasses;
+		$cssclasses = $gc_gb_ctaclasses;
 	}
 
 	if ( $link ):
-		$link_url    = $link['url'];
-		$link_title  = $link['title'];
-		$link_target = $link['target'] ? $link['target'] : '_self';
-		$return['link'] = '<a class="btn ' . $classsess . '" href="' . esc_url( $link_url ) . '" target="' . esc_attr( $link_target ) . '">' . esc_html( $link_title ) . '</a>';
-		$return['linkpreview'] = '<a class="btn ' . $classsess . '" href="#" target="' . esc_attr( $link_target ) . '">' . esc_html( $link_title ) . '</a>';
+		$link_url              = $link['url'];
+		$link_title            = $link['title'];
+		$link_target           = $link['target'] ? $link['target'] : '_self';
+		$return['link']        = '<a class="btn ' . $cssclasses . '" href="' . esc_url( $link_url ) . '" target="' . esc_attr( $link_target ) . '">' . esc_html( $link_title ) . '</a>';
+		$return['linkpreview'] = '<a class="btn ' . $cssclasses . '" href="#" target="' . esc_attr( $link_target ) . '">' . esc_html( $link_title ) . '</a>';
 	endif;
 
 	return $return;

--- a/gutenberg-blocks/cta-block.php
+++ b/gutenberg-blocks/cta-block.php
@@ -1,0 +1,70 @@
+<?php
+
+add_action( 'acf/init', 'gb_add_calltoaction_block' );
+
+function gb_add_calltoaction_block() {
+
+	// Check function exists.
+	if ( function_exists( 'acf_register_block_type' ) ) {
+
+		// register a testimonial block.
+		acf_register_block_type( [
+			'name'            => 'gc/ctalink',
+			'title'           => _x( 'GC Call To Action (CTA)', 'Block titel', 'gctheme' ),
+			'description'     => _x( 'Opvallende link', 'Block description', 'gctheme' ),
+			'render_callback' => 'gb_render_calltoaction_block',
+			'category'        => 'gc-blocks',
+			'icon'            => 'megaphone',
+			'keywords'        => [ 'link' ],
+		] );
+	}
+}
+
+
+function gb_render_calltoaction_block( $block, $content = '', $is_preview = FALSE ) {
+
+	$context = Timber::context();
+
+	// Store block values.
+	$context['block'] = $block;
+
+	// Store field values.
+	$context['fields'] = get_fields();
+
+	// Store $is_preview value.
+	$context['is_preview'] = $is_preview;
+
+	$context['ctalink'] = cta_block_get_data();
+
+	// Render the block.
+	Timber::render( 'gutenberg-blocks/cta-block.twig', $context );
+}
+
+/*
+ * returns an array for the downloads section
+ */
+function cta_block_get_data() {
+
+	global $post;
+
+	$return           = [];
+	$link             = get_field( 'gc_gb_ctalink' );
+	$gc_gb_ctaclasses = get_field( 'gc_gb_ctaclasses' );
+
+	$classsess = 'btn btn--primary';
+
+	if ( $gc_gb_ctaclasses ) {
+		$classsess = $gc_gb_ctaclasses;
+	}
+
+	if ( $link ):
+		$link_url    = $link['url'];
+		$link_title  = $link['title'];
+		$link_target = $link['target'] ? $link['target'] : '_self';
+		$return['link'] = '<a class="btn ' . $classsess . '" href="' . esc_url( $link_url ) . '" target="' . esc_attr( $link_target ) . '">' . esc_html( $link_title ) . '</a>';
+		$return['linkpreview'] = '<a class="btn ' . $classsess . '" href="#" target="' . esc_attr( $link_target ) . '">' . esc_html( $link_title ) . '</a>';
+	endif;
+
+	return $return;
+
+}

--- a/gutenberg-blocks/download-block.php
+++ b/gutenberg-blocks/download-block.php
@@ -9,7 +9,7 @@ function gb_add_downloadblock() {
 
 		// register a testimonial block.
 		acf_register_block_type( [
-			'name'            => 'GC downloads',
+			'name'            => 'gc/downloads',
 			'title'           => _x( 'GC Downloads', 'Block titel', 'gctheme' ),
 			'description'     => _x( 'Lijst met downloads', 'Block description', 'gctheme' ),
 			'render_callback' => 'gb_render_download_block',

--- a/gutenberg-blocks/links-block.php
+++ b/gutenberg-blocks/links-block.php
@@ -1,0 +1,73 @@
+<?php
+
+add_action( 'acf/init', 'gb_add_linksblock' );
+
+function gb_add_linksblock() {
+
+	// Check function exists.
+	if ( function_exists( 'acf_register_block_type' ) ) {
+
+		// register a testimonial block.
+		acf_register_block_type( [
+			'name'            => 'gc/links',
+			'title'           => _x( 'GC Links', 'Block titel', 'gctheme' ),
+			'description'     => _x( 'Lijst met Links', 'Block description', 'gctheme' ),
+			'render_callback' => 'gb_render_links_block',
+			'category'        => 'gc-blocks',
+			'icon'            => 'download',
+			'keywords'        => [ 'links', 'files', 'attachments' ],
+		] );
+	}
+}
+
+
+function gb_render_links_block( $block, $content = '', $is_preview = FALSE ) {
+
+	$context = Timber::context();
+
+	// Store block values.
+	$context['block'] = $block;
+
+	// Store field values.
+	$context['fields'] = get_fields();
+
+	// Store $is_preview value.
+	$context['is_preview'] = $is_preview;
+
+	$context['links'] = links_block_get_data();
+
+	// Render the block.
+	Timber::render( 'gutenberg-blocks/links-block.twig', $context );
+
+}
+
+/*
+ * returns an array for the downloads section
+ */
+function links_block_get_data() {
+
+	global $post;
+	$return = [];
+
+	if ( 'ja' === get_field( 'links_tonen' ) ) {
+
+		while ( have_rows( 'links_items' ) ) : the_row();
+
+			$item              = [];
+			$item['title']     = get_sub_field( 'link_item_title' );
+			$item['descr']     = get_sub_field( 'link_item_description' );
+			$item['url']       = get_sub_field( 'link_item_url' );
+			$return['items'][] = $item;
+
+		endwhile;
+
+		if ( $return['items'] ) {
+			$return['title'] = get_field( 'links_title' );
+			$return['desc']  = get_field( 'links_description' );
+		}
+
+	}
+
+	return $return;
+
+}

--- a/gutenberg-blocks/related-block.php
+++ b/gutenberg-blocks/related-block.php
@@ -1,6 +1,48 @@
 <?php
 
 
+add_action( 'acf/init', 'gb_add_related_block' );
+
+function gb_add_related_block() {
+
+	// Check function exists.
+	if ( function_exists( 'acf_register_block_type' ) ) {
+
+		// register a testimonial block.
+		acf_register_block_type( [
+			'name'            => 'gc/related',
+			'title'           => _x( 'GC gerelateerde content', 'Block titel', 'gctheme' ),
+			'description'     => _x( 'Tonen van gerelateerde content in een apart block', 'Block description', 'gctheme' ),
+			'render_callback' => 'gb_render_related_block',
+			'category'        => 'gc-blocks',
+			'icon'            => 'megaphone', // todo: eigen icon voor dit block
+			'keywords'        => [ 'link', 'text', 'image' ],
+		] );
+	}
+}
+
+
+function gb_render_related_block( $block, $content = '', $is_preview = FALSE ) {
+
+	$context = Timber::context();
+
+	// Store block values.
+	$context['block'] = $block;
+
+	// Store field values.
+	$context['fields'] = get_fields();
+
+	// Store $is_preview value.
+	$context['is_preview'] = $is_preview;
+
+	$context['related'] = related_block_get_data();
+
+	// Render the block.
+	Timber::render( 'sections/section-related.html.twig', $context );
+}
+
+
+
 /*
  * returns an array for the related section
  */
@@ -12,32 +54,58 @@ function related_block_get_data() {
 	if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) ) {
 
 		$featured_posts = get_field( 'content_block_items' );
+		$themakleuren   = [];
 
 		if ( $featured_posts ):
 
 			foreach ( $featured_posts as $post ):
 
-				$item['title']  = get_the_title( $post );
+				$item['title'] = get_the_title( $post );
 
-				$item           = [];
-				$item['title']  = get_the_title( $post );
-				$item['descr']  = get_the_excerpt( $post );
-				$item['type']   = get_post_type( $post );
-				$item['url']    = get_the_permalink( $post );
-				$image          = get_the_post_thumbnail( $post->ID, 'large', [] );
-				$item['img']    = $image;
+				$item          = [];
+				$item['title'] = get_the_title( $post );
+				$item['descr'] = get_the_excerpt( $post );
+				$item['type']  = get_post_type( $post );
+				$item['url']   = get_the_permalink( $post );
+				$image         = get_the_post_thumbnail( $post->ID, 'large', [] );
+				$item['img']   = $image;
 
-				if ( 'post' ==  get_post_type( $post ) ) {
+				if ( 'tips' == get_post_type( $post ) ) {
 
-					$item['meta'][]  = [
-						'title' => 'date',
-						'descr' => get_the_time( get_option('date_format'), $post->ID),
-					];
+					// het is een tip
+					// eerst checken of we al alle themakleuren hebben
+					if ( ! $themakleuren ) {
+						$themakleuren = get_themakleuren();
+					}
 
-					$item['meta'][]  = [
+					$item['nr']     = sprintf( _x( 'Tip %s', 'Label tip-nummer', 'gctheme' ), get_post_meta( $post->ID, 'tip-nummer', TRUE ) );
+					$item['toptip'] = FALSE;
+					$is_toptip      = get_post_meta( $post->ID, 'is_toptip', TRUE );
+
+					if ( $is_toptip ) {
+						$item['toptip']      = TRUE;
+						$item['toptiptekst'] = 'Toptip';
+					}
+
+					$taxonomie = get_the_terms( $post->ID, GC_TIPTHEMA );
+
+					if ( isset( $themakleuren[ $taxonomie[0]->term_id ] ) ) {
+						$item['category'] = $themakleuren[ $taxonomie[0]->term_id ];
+					}
+
+
+				} elseif ( 'post' == get_post_type( $post ) ) {
+
+					$item['meta'][] = [
 						'title' => 'author',
 						'descr' => get_the_author_meta( 'display_name', $post->post_author ),
 					];
+
+					$item['meta'][] = [
+						'title' => 'date',
+						'descr' => get_the_time( get_option( 'date_format' ), $post->ID ),
+					];
+
 				}
 
 				$return['items'][] = $item;
@@ -46,9 +114,21 @@ function related_block_get_data() {
 
 		endif;
 
+		$columncounter = '2';
+
+		if ( count( $return['items'] ) < 2 ) {
+			$columncounter = '1';
+		} elseif ( count( $return['items'] ) === 4 ) {
+			$columncounter = '2';
+		} elseif ( count( $return['items'] ) > 2 ) {
+			$columncounter = '3';
+		}
+
+		$return['columncounter'] = $columncounter;
+
 		if ( $return['items'] ) {
-			$return['title'] = get_field( 'content_block_title' ) ? get_field( 'content_block_title' ) : _x( 'Gerelateerd', 'Titel boven gerelateerde links', 'gctheme' );
-			$return['desc']  = 'DESC HIER: ' . get_field( 'downloads_description' );
+			$return['description'] = get_field( 'content_block_description' ) ? get_field( 'content_block_description' ) : '';
+			$return['title']       = get_field( 'content_block_title' ) ? get_field( 'content_block_title' ) : '';
 		}
 
 	}

--- a/gutenberg-blocks/related-block.php
+++ b/gutenberg-blocks/related-block.php
@@ -1,0 +1,58 @@
+<?php
+
+
+/*
+ * returns an array for the related section
+ */
+function related_block_get_data() {
+
+	global $post;
+	$return = [];
+
+	if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) ) {
+
+		$featured_posts = get_field( 'content_block_items' );
+
+		if ( $featured_posts ):
+
+			foreach ( $featured_posts as $post ):
+
+				$item['title']  = get_the_title( $post );
+
+				$item           = [];
+				$item['title']  = get_the_title( $post );
+				$item['descr']  = get_the_excerpt( $post );
+				$item['type']   = get_post_type( $post );
+				$item['url']    = get_the_permalink( $post );
+				$image          = get_the_post_thumbnail( $post->ID, 'large', [] );
+				$item['img']    = $image;
+
+				if ( 'post' ==  get_post_type( $post ) ) {
+
+					$item['meta'][]  = [
+						'title' => 'date',
+						'descr' => get_the_time( get_option('date_format'), $post->ID),
+					];
+
+					$item['meta'][]  = [
+						'title' => 'author',
+						'descr' => get_the_author_meta( 'display_name', $post->post_author ),
+					];
+				}
+
+				$return['items'][] = $item;
+
+			endforeach;
+
+		endif;
+
+		if ( $return['items'] ) {
+			$return['title'] = get_field( 'content_block_title' ) ? get_field( 'content_block_title' ) : _x( 'Gerelateerd', 'Titel boven gerelateerde links', 'gctheme' );
+			$return['desc']  = 'DESC HIER: ' . get_field( 'downloads_description' );
+		}
+
+	}
+
+	return $return;
+
+}

--- a/gutenberg-blocks/textimage-block.php
+++ b/gutenberg-blocks/textimage-block.php
@@ -1,0 +1,94 @@
+<?php
+
+add_action( 'acf/init', 'gb_add_textimage_block' );
+
+function gb_add_textimage_block() {
+
+	// Check function exists.
+	if ( function_exists( 'acf_register_block_type' ) ) {
+
+		// register a testimonial block.
+		acf_register_block_type( [
+			'name'            => 'gc/textimage',
+			'title'           => _x( 'GC Text + image', 'Block titel', 'gctheme' ),
+			'description'     => _x( 'Tekst en plaatje naast elkaar', 'Block description', 'gctheme' ),
+			'render_callback' => 'gb_render_textimage_block',
+			'category'        => 'gc-blocks',
+			'icon'            => 'megaphone', // todo: eigen icon voor dit block
+			'keywords'        => [ 'link', 'text', 'image' ],
+		] );
+	}
+}
+
+
+function gb_render_textimage_block( $block, $content = '', $is_preview = FALSE ) {
+
+	$context = Timber::context();
+
+	// Store block values.
+	$context['block'] = $block;
+
+	// Store field values.
+	$context['fields'] = get_fields();
+
+	// Store $is_preview value.
+	$context['is_preview'] = $is_preview;
+
+	$context['textimage'] = textimage_block_get_data();
+
+	// Render the block.
+	Timber::render( 'gutenberg-blocks/textimage-block.twig', $context );
+}
+
+/*
+ * returns an array for the downloads section
+ */
+function textimage_block_get_data() {
+
+	global $post;
+
+	$return                = [];
+	$gc_gt_textimage_text  = get_field( 'gc_gt_textimage_text' );
+	$gc_gt_textimage_image = get_field( 'gc_gt_textimage_image' );
+	$cssclasses           = [ 'section' ];
+
+	if ( $gc_gt_textimage_text && $gc_gt_textimage_image ) {
+
+		$cssclasses[] = 'section--text-image';
+
+		$size = 'full'; // (thumbnail, medium, large, full or custom size)
+
+		$return['text'] = $gc_gt_textimage_text;
+
+		if ( $gc_gt_textimage_image ) {
+//			$return['image'] = 'plaatje: ' . $gc_gt_textimage_image;
+			$return['image'] = '<figure class="text-image__image">' . wp_get_attachment_image( $gc_gt_textimage_image, $size ) . '</figure>';
+		}
+
+		if ( 'none' != get_field( 'gc_gt_textimage_alignment' ) ) {
+			$cssclasses[] = get_field( 'gc_gt_textimage_alignment' );
+		}
+
+		if ( 'none' != get_field( 'gc_gt_textimage_width' ) ) {
+			$cssclasses[] = get_field( 'gc_gt_textimage_width' );
+		}
+
+		if ( 'none' != get_field( 'gc_gt_textimage_background' ) ) {
+			$cssclasses[] = get_field( 'gc_gt_textimage_background' );
+		}
+
+
+	}
+
+
+	//	section section--text-image l-has-background bg-color--light align--right
+
+
+	if ( $cssclasses ) {
+		$return['cssclass'] = implode( ' ', $cssclasses );
+	}
+
+
+	return $return;
+
+}

--- a/gutenberg-blocks/textimage-block.php
+++ b/gutenberg-blocks/textimage-block.php
@@ -14,7 +14,7 @@ function gb_add_textimage_block() {
 			'description'     => _x( 'Tekst en plaatje naast elkaar', 'Block description', 'gctheme' ),
 			'render_callback' => 'gb_render_textimage_block',
 			'category'        => 'gc-blocks',
-			'icon'            => 'megaphone', // todo: eigen icon voor dit block
+			'icon'            => 'id', // todo: eigen icon voor dit block
 			'keywords'        => [ 'link', 'text', 'image' ],
 		] );
 	}

--- a/page.php
+++ b/page.php
@@ -32,13 +32,18 @@ if ( 'ja' === get_field( 'downloads_tonen' ) && get_field( 'download_items' ) ) 
 
 }
 
-//if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) && get_field( 'download_items' ) ) {
 if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) ) {
 
 	$context['related'] = related_block_get_data();
 
+}
+
+if ( 'ja' === get_field( 'links_tonen' ) ) {
+
+	$context['links'] = links_block_get_data();
 
 }
+
 
 Timber::render( [
 	'page-' . $timber_post->post_name . '.twig',

--- a/page.php
+++ b/page.php
@@ -32,6 +32,14 @@ if ( 'ja' === get_field( 'downloads_tonen' ) && get_field( 'download_items' ) ) 
 
 }
 
+//if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) && get_field( 'download_items' ) ) {
+if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) ) {
+
+	$context['related'] = related_block_get_data();
+
+
+}
+
 Timber::render( [
 	'page-' . $timber_post->post_name . '.twig',
 	'page.twig',

--- a/single.php
+++ b/single.php
@@ -13,6 +13,24 @@ $context         = Timber::context();
 $timber_post     = Timber::query_post();
 $context['post'] = $timber_post;
 
+if ( 'ja' === get_field( 'downloads_tonen' ) && get_field( 'download_items' ) ) {
+
+	$context['downloads'] = download_block_get_data();
+
+}
+
+if ( 'ja' === get_field( 'gerelateerde_content_toevoegen' ) ) {
+
+	$context['related'] = related_block_get_data();
+
+}
+
+if ( 'ja' === get_field( 'links_tonen' ) ) {
+
+	$context['links'] = links_block_get_data();
+
+}
+
 if ( post_password_required( $timber_post->ID ) ) {
 	Timber::render( 'single-password.twig', $context );
 } else {

--- a/template-alle-tips.php
+++ b/template-alle-tips.php
@@ -8,23 +8,21 @@
  */
 
 
-$context = Timber::context();
-
-$timber_post          = new Timber\Post();
+$context              = Timber::context();
+$timber_post          = Timber::query_post();
 $context['post']      = $timber_post;
-$context['filters']   = array();
-$context['tipkaarts'] = array();
-$themakleuren         = array();
-$card                 = array();
-$context              = Timber::get_context();
+$context['filters']   = [];
+$context['tipkaarts'] = [];
+$themakleuren         = [];
+$card                 = [];
 
 // eerst alle tipthema's langs om de kleuren op te halen
-$args  = array(
+$args  = [
 	'taxonomy'   => GC_TIPTHEMA,
-	'hide_empty' => true,
+	'hide_empty' => TRUE,
 	'orderby'    => 'name',
 	'order'      => 'ASC',
-);
+];
 $terms = get_terms( $args );
 
 if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
@@ -37,11 +35,15 @@ if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 		if ( $themakleur ) {
 
 			$themakleuren[ $term->term_id ] = $themakleur;
+			/*
+			 * TODO: filters weer terug zetten
+			 * filter array leeghouden, zodat frontend nog even zo schoon mogelijk blijft
 			$context['filters'][]           = array(
 				'id'    => $term->term_id,
 				'name'  => $term->name,
 				'class' => $themakleur,
 			);
+			*/
 
 		} else {
 			// kleur ontbreekt
@@ -49,16 +51,16 @@ if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 	}
 }
 
-$args = array(
+$args = [
 	// Get post type project
 	'post_type'      => GC_TIP_CPT,
 	// Get all posts
 	'posts_per_page' => - 1,
 	'post_status'    => 'publish',
-	'orderby'        => array(
-		'date' => 'DESC'
-	)
-);
+	'orderby'        => [
+		'date' => 'DESC',
+	],
+];
 
 $the_query = new WP_Query( $args );
 
@@ -67,17 +69,17 @@ if ( $the_query->have_posts() ) {
 	while ( $the_query->have_posts() ) {
 
 		$the_query->the_post();
-		$card = array();
+		$card          = [];
 		$taxonomie     = get_the_terms( $post->ID, GC_TIPTHEMA );
 		$card['title'] = od_wbvb_custom_post_title( get_the_title() );
-		$card['nr']    = sprintf( _x( 'Tip %s', 'Label tip-ummer', 'gctheme' ), get_post_meta( $post->ID, 'tip-nummer', true ) );
+		$card['nr']    = sprintf( _x( 'Tip %s', 'Label tip-ummer', 'gctheme' ), get_post_meta( $post->ID, 'tip-nummer', TRUE ) );
 		$card['url']   = get_the_permalink();
-		$is_toptip     = get_post_meta( $post->ID, 'is_toptip', true );
+		$is_toptip     = get_post_meta( $post->ID, 'is_toptip', TRUE );
 		if ( $is_toptip ) {
-			$card['toptip'] = true;
+			$card['toptip']      = TRUE;
 			$card['toptiptekst'] = 'Toptip';
 		} else {
-			$card['toptip'] = false;
+			$card['toptip'] = FALSE;
 		}
 		if ( isset( $themakleuren[ $taxonomie[0]->term_id ] ) ) {
 			$card['category'] = $themakleuren[ $taxonomie[0]->term_id ];
@@ -92,15 +94,4 @@ if ( $the_query->have_posts() ) {
 wp_reset_postdata();
 
 
-/*
-"26": {
-	"title": "Meet en verbeter continu",
-    "category": "Procesaanpak",
-    "url": "tip-procesaanpak.php",
-    "toptip": "ja"
-  },
- *
- */
-
-
-Timber::render( array( 'template-alle-tips.twig', 'page.twig' ), $context );
+Timber::render( [ 'template-alle-tips.twig', 'page.twig' ], $context );

--- a/template-alle-tips.php
+++ b/template-alle-tips.php
@@ -13,43 +13,9 @@ $timber_post          = Timber::query_post();
 $context['post']      = $timber_post;
 $context['filters']   = [];
 $context['tipkaarts'] = [];
-$themakleuren         = [];
+$themakleuren         = get_themakleuren();
 $card                 = [];
 
-// eerst alle tipthema's langs om de kleuren op te halen
-$args  = [
-	'taxonomy'   => GC_TIPTHEMA,
-	'hide_empty' => TRUE,
-	'orderby'    => 'name',
-	'order'      => 'ASC',
-];
-$terms = get_terms( $args );
-
-if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-	$count = count( $terms );
-
-	foreach ( $terms as $term ) {
-
-		$themakleur = get_field( 'kleur_en_icoon_tipthema', GC_TIPTHEMA . '_' . $term->term_id );
-
-		if ( $themakleur ) {
-
-			$themakleuren[ $term->term_id ] = $themakleur;
-			/*
-			 * TODO: filters weer terug zetten
-			 * filter array leeghouden, zodat frontend nog even zo schoon mogelijk blijft
-			$context['filters'][]           = array(
-				'id'    => $term->term_id,
-				'name'  => $term->name,
-				'class' => $themakleur,
-			);
-			*/
-
-		} else {
-			// kleur ontbreekt
-		}
-	}
-}
 
 $args = [
 	// Get post type project
@@ -72,7 +38,7 @@ if ( $the_query->have_posts() ) {
 		$card          = [];
 		$taxonomie     = get_the_terms( $post->ID, GC_TIPTHEMA );
 		$card['title'] = od_wbvb_custom_post_title( get_the_title() );
-		$card['nr']    = sprintf( _x( 'Tip %s', 'Label tip-ummer', 'gctheme' ), get_post_meta( $post->ID, 'tip-nummer', TRUE ) );
+		$card['nr']    = sprintf( _x( 'Tip %s', 'Label tip-nummer', 'gctheme' ), get_post_meta( $post->ID, 'tip-nummer', TRUE ) );
 		$card['url']   = get_the_permalink();
 		$is_toptip     = get_post_meta( $post->ID, 'is_toptip', TRUE );
 		if ( $is_toptip ) {

--- a/template-landingspagina.php
+++ b/template-landingspagina.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Template Name: Landingspagina
+ *
+ * @package  WordPress
+ * @subpackage  Timber
+ * @since    Timber 0.1
+ */
+
+$context = Timber::context();
+
+$timber_post        = new Timber\Post();
+$context['post']    = $timber_post;
+
+
+
+Timber::render( array( 'page-sitemap.twig', 'page.twig' ), $context );

--- a/templates/components/card--tipkaart.html.twig
+++ b/templates/components/card--tipkaart.html.twig
@@ -6,7 +6,7 @@
       <span class="tipkaart__toptip">{{ toptiptekst }}</span>
     {% endif %}
 
-    <span class="tipkaart__nummer">Tip {{ nr }}</span>
+    <span class="tipkaart__nummer">{{ nr }}</span>
     <h3 class="tipkaart__title">{{ title }}</h3>
 
     <div class="tipkaart__categorie">

--- a/templates/components/card.html.twig
+++ b/templates/components/card.html.twig
@@ -9,7 +9,7 @@
 <div class="card{{ img ? ' card--with-image' : '' }}{{ type ? ' card--type-' ~ type : '' }}">
   {% if img is not empty %}
     <div class="card__image">
-      <img src="/uploads/{{ img }}" alt="{{ title }}">
+      {{ img }}
     </div>
   {% endif %}
   <div class="card__content">

--- a/templates/components/card.html.twig
+++ b/templates/components/card.html.twig
@@ -1,35 +1,31 @@
-{% if title is empty %}
-  {% set title = 'Kaartje zonder titel' %}
-{% endif %}
+{% if type == 'tips' %}
+  {% include 'components/card--tipkaart.html.twig' %}
+{% else %}
+  <div class="card{{ img ? ' card--with-image' : '' }}{{ type ? ' card--type-' ~ type : '' }}">
+    {% if img is not empty %}
+      <div class="card__image">
+        {{ img }}
+      </div>
+    {% endif %}
+    <div class="card__content">
+      {% if type == 'event' %}
+        {% include 'components/date-badge.html.twig' %}
+      {% endif %}
+      <h2 class="card__title">
+        <a class="arrow-link" href="{{ url }}">
+          <span class="arrow-link__text">
+            {{ title }}
+          </span>
+          <span class="arrow-link__icon"></span>
+        </a>
+      </h2>
+      <p class="card__description">
+        {{ descr }}
+      </p>
 
-{% if descr is empty %}
-  {% set descr = 'Dit is de omschrijving van het kaartje. Hier kan de samenvatting in of de eerste tekst van de detailpagina.' %}
-{% endif %}
-
-<div class="card{{ img ? ' card--with-image' : '' }}{{ type ? ' card--type-' ~ type : '' }}">
-  {% if img is not empty %}
-    <div class="card__image">
-      {{ img }}
+      {% if meta %}
+        {% include 'components/meta-data.html.twig' with {'items': meta} %}
+      {% endif %}
     </div>
-  {% endif %}
-  <div class="card__content">
-    {% if type == 'event' %}
-      {% include 'components/date-badge.html.twig' %}
-    {% endif %}
-    <h2 class="card__title">
-      <a class="arrow-link" href="{{ url }}">
-        <span class="arrow-link__text">
-          {{ title }}
-        </span>
-        <span class="arrow-link__icon"></span>
-      </a>
-    </h2>
-    <p class="card__description">
-      {{ descr }}
-    </p>
-
-    {% if meta %}
-      {% include 'components/meta-data.html.twig' with {'items': meta} %}
-    {% endif %}
   </div>
-</div>
+{% endif %}

--- a/templates/components/date-badge.html.twig
+++ b/templates/components/date-badge.html.twig
@@ -1,0 +1,78 @@
+{% if start_date and end_date is empty %}
+
+  {% set day = start_date|date('d') %}
+  {% set month = start_date|date('M') %}
+  {% set year = start_date|date('Y') %}
+
+  <span class="date-badge" itemprop="datePublished" content="{{ day }} {{ month }} {{ year }}">
+
+  <span class="date-badge__day">{{ day }}</span>
+  <span class="date-badge__month">{{ month }}</span>
+  <span class="date-badge__year visually-hidden">{{ year }}</span>
+</span>
+
+{% elseif start_date and end_date %}
+
+  {#start date#}
+  {% set s_day = start_date|date('d') %}
+  {% set s_month = start_date|date('M') %}
+  {% set s_year = start_date|date('Y') %}
+
+  {#end date#}
+  {% set e_day = end_date|date('d') %}
+  {% set e_month = end_date|date('M') %}
+  {% set e_year = end_date|date('Y') %}
+
+  {% if s_month == e_month %}
+    {# start and end date in same month #}
+
+    {% if s_day == e_day %}
+      {% set day = s_day %}
+    {% else %}
+      {% set day = s_day ~ ' - ' ~ e_day %}
+    {% endif %}
+
+    {% set month = s_month %}
+
+    <span class="date-badge" itemprop="datePublished" content="{{ day }} {{ month }} {{ year }}">
+      <span class="date-badge__day">{{ day }}</span>
+      <span class="date-badge__month">{{ month }}</span>
+      <span class="date-badge__year visually-hidden">{{ year }}</span>
+    </span>
+
+  {% else %}
+    {# start and end date in different month #}
+
+    <span class="date-badge date-badge--multiple" itemprop="datePublished" content="{{ day }} {{ month }} {{ year }}">
+      <span class="date-badge__from"><span class="day">{{ s_day }}</span> {{ s_month }}</span>
+      <span class="date-badge__till"><span class="day">{{ e_day }}</span> {{ e_month }}</span>
+    </span>
+
+  {% endif %}
+
+
+{% elseif start_date is empty %}
+
+  {% if post_date %}
+    {% set day = post_date|date('d') %}
+    {% set month = post_date|date('M') %}
+    {% set year = post_date|date('Y') %}
+  {% else %}
+    {% set day = "now"|date('d') %}
+    {% set month = "now"|date('M') %}
+    {% set year = "now"|date('Y') %}
+  {% endif %}
+
+
+  <span class="date-badge{{ modifier? ' ' ~ modifier }}" itemprop="datePublished" content="{{ day }} {{ month }} {{ year }}">
+      <span class="date-badge__day">{{ day }}</span>
+      <span class="date-badge__month">{{ month }}</span>
+      <span class="date-badge__year visually-hidden">{{ year }}</span>
+    </span>
+
+{% endif %}
+
+
+
+
+

--- a/templates/gutenberg-blocks/cta-block.twig
+++ b/templates/gutenberg-blocks/cta-block.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * Block Name: GC CTA
+ *
+ * Gutenberg block voor het tonen van Call To Action (CTA)
+ */
+#}
+
+{% if is_preview %}
+  <style type="text/css">
+    #download-{{ block.id }} {
+      margin-top: 0;
+      overflow: hidden;
+    }
+  </style>
+{% endif %}
+
+  {% if ctalink %}
+    {% if is_preview %}
+      <p>{{ ctalink.linkpreview }}</p>
+      <small>(previewlink, niet klikbaar)</small>
+    {% else %}
+      <p>{{ ctalink.link }}</p>
+    {% endif %}
+
+  {% endif %}

--- a/templates/gutenberg-blocks/links-block.twig
+++ b/templates/gutenberg-blocks/links-block.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * Block Name: GC Links
+ *
+ * Gutenberg block voor het tonen van een lijst met links
+ */
+#}
+
+{% if is_preview %}
+  <style type="text/css">
+    #download-{{ block.id }} {
+      margin-top: 0;
+      overflow: hidden;
+    }
+  </style>
+{% endif %}
+
+	{% if links %}
+    {% include 'sections/section-links.html.twig' with {
+      'section_title': links.title,
+      'section_descr': links.desc,
+      'items': links.items
+    } %}
+  {% else %}
+    {% if is_preview %}
+      <!-- ik weet niet of het handig is om dit te stylen, maar zo weet de redacteur in ieder geval dat het een aanwijzing is -->
+      <p style="background: black; color: white; padding: 1rem; line-height: 1.5;">Kies 'ja' om dit links-block te gebruiken en voer 1 of meer URLs in.</p>
+    {% endif %}
+  {% endif %}

--- a/templates/gutenberg-blocks/textimage-block.twig
+++ b/templates/gutenberg-blocks/textimage-block.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * Block Name: GC Gutenberg block for text and image
+ *
+ * Gutenberg block voor het tonen van Call To Action (CTA)
+ */
+#}
+
+{% if is_preview %}
+  <style type="text/css">
+    #download-{{ block.id }} {
+      margin-top: 0;
+      overflow: hidden;
+    }
+  </style>
+{% endif %}
+
+
+  {% if textimage.text %}
+
+    <div class="{{ textimage.cssclass }}">
+
+      <div class="l-section-content">
+
+        {% if textimage.image %}
+          {{ textimage.image }}
+        {% endif %}
+
+        <div class="text-image__text">
+          {{ textimage.text }}
+        </div>
+
+      </div>
+    </div>
+
+  {% else %}
+    <small style="background: black; color: white;">Voeg een plaatje en tekst toe.</small>
+  {% endif %}

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -14,6 +14,14 @@
         {{ post.content }}
       </div>
 
+      {% if related %}
+        {% include 'sections/section-related.html.twig' with {
+          'title': related.title,
+          'descr': related.desc,
+          'items': related.items
+        } %}
+      {% endif %}
+
       {% if downloads %}
         {% include 'sections/section-downloads.html.twig' with {
           'title': downloads.title,

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -30,6 +30,14 @@
         } %}
       {% endif %}
 
+      {% if links %}
+        {% include 'sections/section-links.html.twig' with {
+          'section_title': links.title,
+          'section_descr': links.desc,
+          'items': links.items
+        } %}
+      {% endif %}
+
     </section>
   </article>
 

--- a/templates/sections/section-related.html.twig
+++ b/templates/sections/section-related.html.twig
@@ -1,43 +1,54 @@
-
-<section class="section section--related{{ cards ? ' l-item-count-' ~ cards|length : '' }}{{ modifier ? ' section--' ~ modifier }}"{% if id %} id="{{ id }}"{% endif %}>
+<section
+  class="section section--related{{ related.columncounter ? ' l-item-count-' ~ related.columncounter : '' }}{{ modifier ? ' section--' ~ modifier }}"{% if id %} id="{{ id }}"{% endif %}>
 
   {# Wrapper for section intro #}
-  {% if title or description %}
-  <div class="l-section-top">
+  {% if related.title or related.description %}
+    <div class="l-section-top">
 
-    {% if title %}
-      <h2 class="section__title">
-      {{ title }}
-      </h2>
-    {% endif %}
+      {% if related.title %}
+        <h2 class="section__title">
+          {{ related.title }}
+        </h2>
+      {% endif %}
 
-    {% if description %}
-    <p class="section__description">
-      {{ description }}
-    </p>
-    {% endif %}
-  </div>
+      {% if related.description %}
+        <p class="section__description">
+          {{ related.description }}
+        </p>
+      {% endif %}
+    </div>
   {% endif %}
 
   {# Wrapper for all section content #}
   <div class="l-section-content">
 
-    {% if items %}
-      <div class="grid grid--col-{{ items|length }}">
+    {% if related.items %}
 
-        {% for card in items %}
-          {% include 'components/card.html.twig' with {
-            'title' : card.title,
-            'descr' : card.descr,
-            'img' : card.img,
-            'type' : card.type,
-            'url': card.url,
-            'meta': card.meta,
-          } %}
+      <div class="grid grid--col-{{ is_preview ? '2' : related.columncounter }}">
+
+        {% for card in related.items %}
+
+            {% include 'components/card.html.twig' with {
+              'title': card.title,
+              'descr' : card.descr,
+              'img' : card.img,
+              'type' : card.type,
+              'nr' : card.nr,
+              'category' : card.category,
+              'toptip' : card.toptip,
+              'toptiptekst' : card.toptiptekst,
+              'url': is_preview ? '#' : card.url,
+              'meta': card.meta,
+            } %}
+
         {% endfor %}
       </div>
 
+    {% else %}
+      <small style="background: black; color: white;">Selecteer gerelateerde content, zoals berichten of
+        pagina's</small>
     {% endif %}
+
 
   </div>
 </section>

--- a/templates/sections/section-related.html.twig
+++ b/templates/sections/section-related.html.twig
@@ -1,6 +1,5 @@
-{% set base_url = '/uploads' %}
 
-<section class="section section--related{{ cards ? ' l-item-count-' ~ cards|length : '' }}{{ modifier ? ' section--' ~ modifier }}">
+<section class="section section--related{{ cards ? ' l-item-count-' ~ cards|length : '' }}{{ modifier ? ' section--' ~ modifier }}"{% if id %} id="{{ id }}"{% endif %}>
 
   {# Wrapper for section intro #}
   {% if title or description %}
@@ -19,15 +18,17 @@
     {% endif %}
   </div>
 
+  {% else %}
+    neen
   {% endif %}
 
   {# Wrapper for all section content #}
   <div class="l-section-content">
 
-    {% if cards %}
-      <div class="grid grid--col-{{ cards|length }}">
+    {% if items %}
+      <div class="grid grid--col-{{ items|length }}">
 
-        {% for card in cards %}
+        {% for card in items %}
           {% include 'components/card.html.twig' with {
             'title' : card.title,
             'descr' : card.descr,
@@ -37,41 +38,6 @@
             'meta': card.meta,
           } %}
         {% endfor %}
-      </div>
-
-    {% else %}
-
-      <div class="grid grid--col-2">
-        <div class="card">
-          <div class="card__content">
-            <h2 class="card__title">
-              <a class="arrow-link" href="#">
-                <span class="arrow-link__text">Een andere pagina binnen deze website</span>
-                <span class="arrow-link__icon"></span>
-              </a>
-            </h2>
-            <p class="card__description">
-              [Samenvatting] Een andere, interessante pagina die je zeker moet lezen. Snel klikken voor je het mist!
-            </p>
-          </div>
-        </div>
-
-        <div class="card card--with-image">
-          <div class="card__image">
-            <img src="{{ base_url }}/brand-gc.jpg" alt="Gebruiker Centraal Plaatje">
-          </div>
-          <div class="card__content">
-            <h2 class="card__title">
-              <a class="arrow-link" href="#">
-                <span class="arrow-link__text">Een andere pagina binnen deze website</span>
-                <span class="arrow-link__icon"></span>
-              </a>
-            </h2>
-            <p class="card__description">
-              [Samenvatting] Een andere, interessante pagina die je zeker moet lezen. Snel klikken voor je het mist!
-            </p>
-          </div>
-        </div>
       </div>
 
     {% endif %}

--- a/templates/sections/section-related.html.twig
+++ b/templates/sections/section-related.html.twig
@@ -17,9 +17,6 @@
     </p>
     {% endif %}
   </div>
-
-  {% else %}
-    neen
   {% endif %}
 
   {# Wrapper for all section content #}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -15,6 +15,30 @@
 				</div>
 			</section>
 
+      {% if related %}
+        {% include 'sections/section-related.html.twig' with {
+          'title': related.title,
+          'descr': related.desc,
+          'items': related.items
+        } %}
+      {% endif %}
+
+      {% if downloads %}
+        {% include 'sections/section-downloads.html.twig' with {
+          'title': downloads.title,
+          'descr': downloads.desc,
+          'items': downloads.items
+        } %}
+      {% endif %}
+
+      {% if links %}
+        {% include 'sections/section-links.html.twig' with {
+          'section_title': links.title,
+          'section_descr': links.desc,
+          'items': links.items
+        } %}
+      {% endif %}
+
 			<!-- comment box -->
 			<section class="comment-box">
 				<!-- comments -->

--- a/templates/template-alle-tips.twig
+++ b/templates/template-alle-tips.twig
@@ -2,14 +2,14 @@
 
 {% block content %}
 
-      <article class="entry entry--type-overview entry--full">
+      <article class="entry entry--type-overview entry--full" id="post-{{ post.ID }}">
 
         <div class="entry-content">
           <div class="page__intro">
             <header class="entry-header">
-              <h1 class="entry-title">{{ title ? title : 'Onze instrumenten' }}</h1>
+              <h1 class="entry-title">{{ post.title }}</h1>
               {% if intro %}
-                <p>{{ intro }}</p>
+                {{ intro }}
               {% endif %}
             </header>
           </div>


### PR DESCRIPTION
Aan speelset toevoegen van uitgelichte afbeelding
https://trello.com/c/9FOtVKdm/102-speelset-toevoegen-mogelijkheid-voor-een-uitgelichte-afbeelding-soort-van

Gutenberg block voor afbeelding + tekst
https://trello.com/c/6AIhwFNT/77-gutenberg-blok-afbeelding-en-tekst

Gutenberg block voor lijst met links
https://trello.com/c/ags95uQd/79-gt-blok-links

Gutenberg block voor lijst met downloads
https://trello.com/c/VZP9wTrl/92-gutenberg-block-lijst-met-downloads

Gutenberg block voor CTA
https://trello.com/c/PEYWB1lj/96-gutenberg-block-voor-cta

Gutenberg block voor lijst met gerelateerde content
https://trello.com/c/pYWTzLqs/78-gutenberg-block-gerelateerd