### PR TITLE
style: Align WP 'larger' font size with design

### DIFF
--- a/assets/css/editor-styles.css
+++ b/assets/css/editor-styles.css
@@ -3592,7 +3592,8 @@ Gutenberg corrections
 }
 
 .has-larger-font-size {
-  font-size: 120%;
+  /* 122% ~= 22px (based on 18px) */
+  font-size: 122%;
 }
 
 .has-extra-large-font-size {

--- a/functions.php
+++ b/functions.php
@@ -538,7 +538,7 @@ class GebruikerCentraalTheme extends Timber\Site {
 			),
 			array(
 				'name' => esc_attr__( 'Larger', 'gctheme' ),
-				'size' => 24,
+				'size' => 22,
 				'slug' => 'larger',
 			)
 		] );


### PR DESCRIPTION
Wordpress settings for 'larger' font-size did not match Design.